### PR TITLE
configure value to_string method to wrap string values in dbl quotes

### DIFF
--- a/src/kvmap/mod.rs
+++ b/src/kvmap/mod.rs
@@ -111,7 +111,7 @@ mod test {
         map.put("key".to_string(), Value::String("value".to_string()))
             .unwrap();
 
-        assert_eq!(map.get("key"), Ok("value".to_string()));
+        assert_eq!(map.get("key"), Ok("\"value\"".to_string()));
     }
 
     #[test]
@@ -121,7 +121,7 @@ mod test {
         map.put("key".to_string(), Value::String("value".to_string()))
             .unwrap();
 
-        assert_eq!(map.delete("key"), Ok("value".to_string()));
+        assert_eq!(map.delete("key"), Ok("\"value\"".to_string()));
         assert_eq!(
             map.get("key"),
             Err(MapError::KeyNotFound("key".to_string()))
@@ -137,7 +137,7 @@ mod test {
 
         let operation = super::Operation::Get("key".to_string());
 
-        assert_eq!(map.process_operation(operation), Ok("value".to_string()));
+        assert_eq!(map.process_operation(operation), Ok("\"value\"".to_string()));
     }
 
     #[test]
@@ -147,9 +147,9 @@ mod test {
 
         let operation =
             super::Operation::Put("key".to_string(), Value::String("value".to_string()));
-        assert_eq!(map.process_operation(operation), Ok("value".to_string()));
+        assert_eq!(map.process_operation(operation), Ok("\"value\"".to_string()));
 
-        assert_eq!(map.get("key"), Ok("value".to_string()));
+        assert_eq!(map.get("key"), Ok("\"value\"".to_string()));
     }
 
     #[test]
@@ -160,7 +160,7 @@ mod test {
             .unwrap();
 
         let operation = super::Operation::Delete("key".to_string());
-        assert_eq!(map.process_operation(operation), Ok("value".to_string()));
+        assert_eq!(map.process_operation(operation), Ok("\"value\"".to_string()));
         assert_eq!(
             map.get("key"),
             Err(MapError::KeyNotFound("key".to_string()))

--- a/src/kvmap/mod.rs
+++ b/src/kvmap/mod.rs
@@ -137,7 +137,10 @@ mod test {
 
         let operation = super::Operation::Get("key".to_string());
 
-        assert_eq!(map.process_operation(operation), Ok("\"value\"".to_string()));
+        assert_eq!(
+            map.process_operation(operation),
+            Ok("\"value\"".to_string())
+        );
     }
 
     #[test]
@@ -147,7 +150,10 @@ mod test {
 
         let operation =
             super::Operation::Put("key".to_string(), Value::String("value".to_string()));
-        assert_eq!(map.process_operation(operation), Ok("\"value\"".to_string()));
+        assert_eq!(
+            map.process_operation(operation),
+            Ok("\"value\"".to_string())
+        );
 
         assert_eq!(map.get("key"), Ok("\"value\"".to_string()));
     }
@@ -160,7 +166,10 @@ mod test {
             .unwrap();
 
         let operation = super::Operation::Delete("key".to_string());
-        assert_eq!(map.process_operation(operation), Ok("\"value\"".to_string()));
+        assert_eq!(
+            map.process_operation(operation),
+            Ok("\"value\"".to_string())
+        );
         assert_eq!(
             map.get("key"),
             Err(MapError::KeyNotFound("key".to_string()))

--- a/src/operation/value.rs
+++ b/src/operation/value.rs
@@ -33,7 +33,7 @@ impl Value {
 
     pub fn to_string(&self) -> String {
         match self {
-            Value::String(string) => string.to_string(),
+            Value::String(string) => format!("\"{}\"", string),
             Value::Integer(number) => number.to_string(),
             Value::Float(number) => number.to_string(),
             Value::Boolean(boolean) => boolean.to_string(),
@@ -87,7 +87,7 @@ mod test {
     #[test]
     fn converts_string_to_string() {
         assert_eq!(
-            "hello".to_string(),
+            "\"hello\"".to_string(),
             Value::String("hello".to_string()).to_string()
         );
     }

--- a/src/radixtree/mod.rs
+++ b/src/radixtree/mod.rs
@@ -154,7 +154,7 @@ mod test {
             .put("key".to_string(), Value::String("value".to_string()))
             .unwrap();
 
-        assert_eq!(radix.get("key").unwrap(), "value".to_string());
+        assert_eq!(radix.get("key").unwrap(), "\"value\"".to_string());
     }
 
     #[test]
@@ -167,7 +167,7 @@ mod test {
             )
             .unwrap();
 
-        assert_eq!(radix.get("key.abc.def").unwrap(), "value".to_string());
+        assert_eq!(radix.get("key.abc.def").unwrap(), "\"value\"".to_string());
     }
 
     #[test]


### PR DESCRIPTION
Configure the to_string method of the Value enum to return a string wrapped in double quotes.

Closes #20 by configuring the all returned string values with double quotes - and values for integers, floats, booleans, and null without quotes.

Updated unit tests to check for the presence of double quotes when strings are stored.