### PR TITLE
24 kvmap tests write to same log as prod causing errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /log.txt
+/log.test.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +216,17 @@ name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "heck"
@@ -303,6 +335,7 @@ version = "0.1.0"
 dependencies = [
  "assert-json-diff",
  "clap",
+ "directories",
  "mockall",
  "serde",
  "serde_json",
@@ -328,6 +361,12 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "predicates"
@@ -375,6 +414,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -480,6 +539,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +569,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 assert-json-diff = "2.0.2"
 clap = { version = "4.3.5", features = ["derive"] }
+directories = "5.0.1"
 mockall = "0.11.4"
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.99"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,8 +1,9 @@
 use clap::Parser;
+use directories::ProjectDirs;
 use myco_kv::{kvmap::KVMap, wal::WriteAheadLog};
 use std::{
     sync::{Arc, Mutex},
-    thread,
+    thread, fs,
 };
 
 mod repl;
@@ -19,7 +20,15 @@ fn main() {
     let args = Args::parse();
     let port = args.port.unwrap();
 
-    let wal = WriteAheadLog::new("log.txt").expect("Could not open database log.");
+    let system_data_directory = ProjectDirs::from("com", "WVAviator", "MycoKV").expect("Could not access system data directory.");
+    let system_data_directory = system_data_directory.data_dir();
+
+    fs::create_dir_all(system_data_directory).expect("Failed to create data directory");
+
+    let wal_directory = system_data_directory.join("wal.mkv");
+    let wal_directory = wal_directory.to_str().expect("Invalid directory path for write-ahead log");
+
+    let wal = WriteAheadLog::new(wal_directory).expect("Could not open database log.");
     let wal = Arc::new(Mutex::new(wal));
 
     let mut kvmap = KVMap::new(wal);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -19,7 +19,7 @@ fn main() {
     let args = Args::parse();
     let port = args.port.unwrap();
 
-    let wal = WriteAheadLog::new().expect("Could not open database log.");
+    let wal = WriteAheadLog::new("log.txt").expect("Could not open database log.");
     let wal = Arc::new(Mutex::new(wal));
 
     let mut kvmap = KVMap::new(wal);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -2,8 +2,9 @@ use clap::Parser;
 use directories::ProjectDirs;
 use myco_kv::{kvmap::KVMap, wal::WriteAheadLog};
 use std::{
+    fs,
     sync::{Arc, Mutex},
-    thread, fs,
+    thread,
 };
 
 mod repl;
@@ -20,13 +21,16 @@ fn main() {
     let args = Args::parse();
     let port = args.port.unwrap();
 
-    let system_data_directory = ProjectDirs::from("com", "WVAviator", "MycoKV").expect("Could not access system data directory.");
+    let system_data_directory = ProjectDirs::from("com", "WVAviator", "MycoKV")
+        .expect("Could not access system data directory.");
     let system_data_directory = system_data_directory.data_dir();
 
     fs::create_dir_all(system_data_directory).expect("Failed to create data directory");
 
     let wal_directory = system_data_directory.join("wal.mkv");
-    let wal_directory = wal_directory.to_str().expect("Invalid directory path for write-ahead log");
+    let wal_directory = wal_directory
+        .to_str()
+        .expect("Invalid directory path for write-ahead log");
 
     let wal = WriteAheadLog::new(wal_directory).expect("Could not open database log.");
     let wal = Arc::new(Mutex::new(wal));

--- a/src/kvmap/mod.rs
+++ b/src/kvmap/mod.rs
@@ -112,6 +112,8 @@ mod test {
             .unwrap();
 
         assert_eq!(map.get("key"), Ok("\"value\"".to_string()));
+
+        wal_mutex.lock().unwrap().clear().unwrap();
     }
 
     #[test]

--- a/src/kvmap/mod.rs
+++ b/src/kvmap/mod.rs
@@ -106,7 +106,7 @@ mod test {
 
     #[test]
     fn test_put_and_get() {
-        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new().unwrap()));
+        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new("log.test.txt").unwrap()));
         let mut map = super::KVMap::new(wal_mutex.clone());
         map.put("key".to_string(), Value::String("value".to_string()))
             .unwrap();
@@ -116,7 +116,7 @@ mod test {
 
     #[test]
     fn test_delete() {
-        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new().unwrap()));
+        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new("log.test.txt").unwrap()));
         let mut map = super::KVMap::new(wal_mutex.clone());
         map.put("key".to_string(), Value::String("value".to_string()))
             .unwrap();
@@ -130,7 +130,7 @@ mod test {
 
     #[test]
     fn test_process_operation_get() {
-        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new().unwrap()));
+        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new("log.test.txt").unwrap()));
         let mut map = super::KVMap::new(wal_mutex.clone());
         map.put("key".to_string(), Value::String("value".to_string()))
             .unwrap();
@@ -145,7 +145,7 @@ mod test {
 
     #[test]
     fn test_process_operation_put() {
-        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new().unwrap()));
+        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new("log.test.txt").unwrap()));
         let mut map = super::KVMap::new(wal_mutex.clone());
 
         let operation =
@@ -160,7 +160,7 @@ mod test {
 
     #[test]
     fn test_process_operation_delete() {
-        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new().unwrap()));
+        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new("log.test.txt").unwrap()));
         let mut map = super::KVMap::new(wal_mutex.clone());
         map.put("key".to_string(), Value::String("value".to_string()))
             .unwrap();
@@ -178,7 +178,7 @@ mod test {
 
     #[test]
     fn test_process_operation_get_key_not_found() {
-        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new().unwrap()));
+        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new("log.test.txt").unwrap()));
         let mut map = super::KVMap::new(wal_mutex.clone());
 
         let operation = super::Operation::Get("key".to_string());
@@ -190,7 +190,7 @@ mod test {
 
     #[test]
     fn test_process_operation_delete_key_not_found() {
-        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new().unwrap()));
+        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new("log.test.txt").unwrap()));
         let mut map = super::KVMap::new(wal_mutex.clone());
 
         let operation = super::Operation::Delete("key".to_string());
@@ -202,7 +202,7 @@ mod test {
 
     #[test]
     fn test_process_operation_get_multiple() {
-        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new().unwrap()));
+        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new("log.test.txt").unwrap()));
         let mut map = super::KVMap::new(wal_mutex.clone());
 
         map.put("key.abc".to_string(), Value::String("value1".to_string()))
@@ -226,7 +226,7 @@ mod test {
 
     #[test]
     fn test_process_multiple_value_types() {
-        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new().unwrap()));
+        let wal_mutex = Arc::new(Mutex::new(WriteAheadLog::new("log.test.txt").unwrap()));
         let mut map = super::KVMap::new(wal_mutex.clone());
 
         map.put("key.abc".to_string(), Value::String("value1".to_string()))

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -9,6 +9,7 @@ mod wal_error;
 
 pub struct WriteAheadLog {
     file: File,
+    filename: String,
 }
 
 impl WriteAheadLog {
@@ -19,7 +20,7 @@ impl WriteAheadLog {
             .open(filename)
             .map_err(|error| WALError::OpenError(error))?;
 
-        Ok(WriteAheadLog { file })
+        Ok(WriteAheadLog { file, filename: filename.to_string() })
     }
 
     pub fn write(&mut self, operation: &Operation) -> Result<(), WALError> {
@@ -48,7 +49,7 @@ impl WriteAheadLog {
         &self,
         offset: usize,
     ) -> Result<impl Iterator<Item = std::io::Result<String>>, WALError> {
-        let file = File::open("log.txt").map_err(|error| WALError::OpenError(error))?;
+        let file = File::open(&self.filename).map_err(|error| WALError::OpenError(error))?;
         let reader = BufReader::new(file);
         let lines = reader.lines().skip(offset);
         Ok(lines)

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -57,4 +57,9 @@ impl WriteAheadLog {
         let lines = reader.lines().skip(offset);
         Ok(lines)
     }
+
+    pub fn clear(&mut self) -> Result<(), WALError> {
+        self.file = File::create(&self.filename).map_err(|error| WALError::OpenError(error))?;
+        Ok(())
+    }
 }

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -20,7 +20,10 @@ impl WriteAheadLog {
             .open(filename)
             .map_err(|error| WALError::OpenError(error))?;
 
-        Ok(WriteAheadLog { file, filename: filename.to_string() })
+        Ok(WriteAheadLog {
+            file,
+            filename: filename.to_string(),
+        })
     }
 
     pub fn write(&mut self, operation: &Operation) -> Result<(), WALError> {
@@ -28,7 +31,7 @@ impl WriteAheadLog {
             // Ignore get operations since they have no affect on db state
             Operation::Get(_) => return Ok(()),
 
-            Operation::Put(key, value) => format!("PUT {} \"{}\"\n", key, value.to_string()),
+            Operation::Put(key, value) => format!("PUT {} {}\n", key, value.to_string()),
             Operation::Delete(key) => format!("DELETE {}\n", key),
         };
 

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -12,11 +12,11 @@ pub struct WriteAheadLog {
 }
 
 impl WriteAheadLog {
-    pub fn new() -> Result<WriteAheadLog, WALError> {
+    pub fn new(filename: &str) -> Result<WriteAheadLog, WALError> {
         let file = OpenOptions::new()
             .append(true)
             .create(true)
-            .open("log.txt")
+            .open(filename)
             .map_err(|error| WALError::OpenError(error))?;
 
         Ok(WriteAheadLog { file })


### PR DESCRIPTION
Set up directories crate for managing data storage across multiple operating systems.
Now saving main write-ahead log data in wal.mkv file in a system data directory instead of directly inside the project directory
The test data file still saves as a .txt file inside the project directory
Fixed a couple small errors with data storage