### PR TITLE
reconfigure radix tree subtree deletion with recursion

### DIFF
--- a/src/radixtree/radixerror.rs
+++ b/src/radixtree/radixerror.rs
@@ -1,4 +1,4 @@
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RadixError {
     InvalidKey(String),
     KeyNotFound(String),


### PR DESCRIPTION
Implemented recursive deletion method that deletes all nodes in the key path that both have no children and contain no value
Added tests to confirm fix