### PR TITLE
Fix newline in Repl

### DIFF
--- a/src/bin/repl/mod.rs
+++ b/src/bin/repl/mod.rs
@@ -21,7 +21,7 @@ pub fn start(port: u16) {
 
         match send::send_request(&mut stream, &buffer) {
             Ok(response) => {
-                println!("{}", response);
+                print!("{}", response);
             }
             Err(e) => {
                 eprintln!("Error occurred communicating with server: {}", e);


### PR DESCRIPTION
Change output `println!` to just `print!` to avoid automatically-appended newline character (causing double newline characters)