### PR TITLE
35 time to live

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In the future, drivers and SDKs for MycoKV will be developed in many popular lan
 
 ### Basic Usage
 
-At its current stage of development, MycoKV currently supports three commands, `GET`, `PUT`, and `DELETE`. You can store floats, integers, strings, booleans, and even null as values.
+At its current stage of development, MycoKV currently supports three basic commands, `GET`, `PUT`, and `DELETE`. You can store floats, integers, strings, booleans, and even null as values.
 Example usage:
 
 ```
@@ -40,6 +40,38 @@ When sending `GET mykey`, the resulting value is returned as a plain string:
 > GET mykey
 value
 ```
+
+### Expiring Keys
+
+MycoKV supports expiring keys after a certain amount of time. This can be done by using the `EXPIRE` or `EXPIREAT` commands. `EXPIREAT` takes a UNIX timestamp as an argument, while `EXPIRE` takes a number of milliseconds as an argument.
+Example usage:
+
+```
+> PUT mykey "my value"
+"my value"
+> EXPIRE mykey 1000
+OK
+```
+
+After only half a second has passed, you will still be able to get the key's value:
+
+```
+> GET mykey
+"my value"
+```
+
+After one second has passed, the key will no longer exist:
+
+```
+> GET mykey
+E09: Key mykey not found
+```
+
+MycoKV manages key expirations internally by periodically removing expired keys and by ensuring all expired keys are removed before executing any operations such as `GET` or `DELETE`.
+
+If an expiration already exists for the key, calling `EXPIRE` or `EXPIREAT` again will overwrite the previous expiration.
+
+If the key is deleted using the `DELETE` command, any existing expiration will be removed.
 
 ### Purging Data
 

--- a/src/atomicheap/mod.rs
+++ b/src/atomicheap/mod.rs
@@ -1,0 +1,142 @@
+use std::{
+    cmp::Ordering,
+    collections::{BinaryHeap, HashMap},
+    sync::{Arc, Mutex},
+};
+
+#[derive(Debug)]
+pub struct HeapData<T> {
+    key: String,
+    data: T,
+    valid: Mutex<bool>,
+}
+
+impl<T> HeapData<T> {
+    pub fn new(key: String, data: T) -> Self {
+        HeapData {
+            key,
+            data,
+            valid: Mutex::new(true),
+        }
+    }
+}
+
+impl<T> PartialEq for HeapData<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.data.eq(&other.data) && self.key.eq(&other.key)
+    }
+}
+
+impl<T> Eq for HeapData<T> where T: Eq {}
+
+impl<T> Clone for HeapData<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        HeapData {
+            key: self.key.clone(),
+            data: self.data.clone(),
+            valid: Mutex::new(*self.valid.lock().unwrap()),
+        }
+    }
+}
+
+impl<T> Ord for HeapData<T>
+where
+    T: Ord,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.data.cmp(&other.data)
+    }
+}
+
+impl<T> PartialOrd for HeapData<T>
+where
+    T: Ord + PartialOrd,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+pub struct AtomicHeap<T>
+where
+    T: Ord + Clone,
+{
+    heap: BinaryHeap<Arc<HeapData<T>>>,
+    map: HashMap<String, Arc<HeapData<T>>>,
+}
+
+impl<T> AtomicHeap<T>
+where
+    T: Ord + Clone,
+{
+    pub fn new() -> Self {
+        AtomicHeap {
+            heap: BinaryHeap::new(),
+            map: HashMap::new(),
+        }
+    }
+
+    pub fn push(&mut self, key: String, data: T) {
+        let heap_data = Arc::new(HeapData::new(key.clone(), data));
+
+        if let Some(old_heap_data) = self.map.get(&key) {
+            *old_heap_data.valid.lock().unwrap() = false;
+        }
+
+        self.heap.push(heap_data.clone());
+        self.map.insert(key, heap_data);
+    }
+
+    pub fn peek(&mut self) -> Option<T> {
+        while let Some(heap_data) = self.heap.peek().cloned() {
+            if *heap_data.valid.lock().unwrap() {
+                return Some(heap_data.data.clone());
+            } else {
+                self.heap.pop();
+            }
+        }
+
+        None
+    }
+
+    pub fn pop(&mut self) -> Option<T> {
+        while let Some(heap_data) = self.heap.pop() {
+            if *heap_data.valid.lock().unwrap() {
+                self.map.remove(&heap_data.key);
+                return Some(heap_data.data.clone());
+            }
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn invalidates_older_keys() {
+        let mut heap = AtomicHeap::new();
+        heap.push("a".to_string(), 1);
+        heap.push("b".to_string(), 2);
+        heap.push("a".to_string(), 3);
+        heap.push("b".to_string(), 4);
+        heap.push("c".to_string(), 5);
+
+        assert_eq!(heap.peek(), Some(5));
+        assert_eq!(heap.pop(), Some(5));
+        assert_eq!(heap.peek(), Some(4));
+        assert_eq!(heap.pop(), Some(4));
+        assert_eq!(heap.peek(), Some(3));
+        assert_eq!(heap.pop(), Some(3));
+        assert_eq!(heap.peek(), None);
+        assert_eq!(heap.pop(), None);
+    }
+}

--- a/src/atomicheap/mod.rs
+++ b/src/atomicheap/mod.rs
@@ -115,6 +115,19 @@ where
 
         None
     }
+
+    pub fn invalidate(&mut self, key: &str) {
+        if let Some(heap_data) = self.map.get(key) {
+            *heap_data.valid.lock().unwrap() = false;
+        }
+
+        self.map.remove(key);
+    }
+
+    pub fn clear(&mut self) {
+        self.heap.clear();
+        self.map.clear();
+    }
 }
 
 #[cfg(test)]

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -14,6 +14,7 @@ pub enum TransactionError {
     InternalError,
     SerializationFailure,
     MissingCommand,
+    InvalidExpiration(i64),
 }
 
 impl TransactionError {
@@ -73,6 +74,13 @@ impl TransactionError {
             TransactionError::MissingCommand => {
                 format!("{}: Invalid command", self.get_code())
             }
+            TransactionError::InvalidExpiration(timestamp) => {
+                format!(
+                    "{}: Invalid expiration {}",
+                    self.get_code(),
+                    timestamp.to_string()
+                )
+            }
         }
     }
 
@@ -92,6 +100,7 @@ impl TransactionError {
             TransactionError::InternalError => String::from("E12"),
             TransactionError::SerializationFailure => String::from("E13"),
             TransactionError::MissingCommand => String::from("E14"),
+            TransactionError::InvalidExpiration(_) => String::from("E15"),
         }
     }
 }

--- a/src/kvmap/mod.rs
+++ b/src/kvmap/mod.rs
@@ -46,6 +46,7 @@ impl KVMap {
                     }
                     Ok(())
                 }
+                Operation::ExpireAt(key, timestamp) => Ok(()),
                 Operation::Purge => Ok(()),
             };
 
@@ -102,6 +103,7 @@ impl KVMap {
                 }
                 Ok(())
             }
+            Operation::ExpireAt(_key, _timestamp) => Ok(()),
             Operation::Purge => Ok(()),
         }
     }
@@ -126,6 +128,7 @@ impl KVMap {
             Operation::Get(key) => self.get(&key),
             Operation::Put(key, value) => self.put(key.to_string(), value),
             Operation::Delete(key) => self.delete(&key),
+            Operation::ExpireAt(_key, _timestamp) => Ok(String::from("OK")),
             Operation::Purge => self.purge(),
         }
     }

--- a/src/kvmap/mod.rs
+++ b/src/kvmap/mod.rs
@@ -81,6 +81,7 @@ impl KVMap {
     }
 
     pub fn delete(&mut self, key: &str) -> Result<String, TransactionError> {
+        self.exp_heap.invalidate(&key);
         let result = self.radix_tree.delete(key.to_string());
         result.map_err(|_| TransactionError::KeyNotFound(key.to_string()))
     }
@@ -89,6 +90,7 @@ impl KVMap {
         let result = self.radix_tree.purge();
         result
             .map_err(|_| TransactionError::OperationFailure("Unable to purge data.".to_string()))?;
+        self.exp_heap.clear();
         Ok(String::from("OK"))
     }
 

--- a/src/kvmap/mod.rs
+++ b/src/kvmap/mod.rs
@@ -3,6 +3,7 @@ use crate::operation::expiration::Expiration;
 use crate::operation::{value::Value, Operation};
 use crate::radixtree::RadixTree;
 use crate::wal::WriteAheadLog;
+use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
@@ -57,6 +58,7 @@ impl KVMap {
                     }
                     Ok(())
                 }
+                Operation::Time => Ok(()),
                 Operation::Purge => Ok(()),
             };
 
@@ -153,6 +155,7 @@ impl KVMap {
 
                 Ok(())
             }
+            Operation::Time => Ok(()),
             Operation::Purge => Ok(()),
         }
     }
@@ -179,6 +182,11 @@ impl KVMap {
             Operation::Put(key, value) => self.put(key.to_string(), value),
             Operation::Delete(key) => self.delete(&key),
             Operation::ExpireAt(expiration) => self.expire_at(expiration),
+            Operation::Time => Ok(SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_millis()
+                .to_string()),
             Operation::Purge => self.purge(),
         }
     }

--- a/src/kvmap/mod.rs
+++ b/src/kvmap/mod.rs
@@ -46,7 +46,7 @@ impl KVMap {
                     }
                     Ok(())
                 }
-                Operation::ExpireAt(key, timestamp) => Ok(()),
+                Operation::ExpireAt(_expiration) => Ok(()),
                 Operation::Purge => Ok(()),
             };
 
@@ -103,7 +103,7 @@ impl KVMap {
                 }
                 Ok(())
             }
-            Operation::ExpireAt(_key, _timestamp) => Ok(()),
+            Operation::ExpireAt(_expiration) => Ok(()),
             Operation::Purge => Ok(()),
         }
     }
@@ -128,7 +128,7 @@ impl KVMap {
             Operation::Get(key) => self.get(&key),
             Operation::Put(key, value) => self.put(key.to_string(), value),
             Operation::Delete(key) => self.delete(&key),
-            Operation::ExpireAt(_key, _timestamp) => Ok(String::from("OK")),
+            Operation::ExpireAt(_expiration) => Ok(String::from("OK")),
             Operation::Purge => self.purge(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod atomicheap;
 pub mod errors;
 pub mod kvmap;
 pub mod operation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod kvmap;
 pub mod operation;
 pub mod radixtree;
 pub mod wal;
+pub mod worker;

--- a/src/operation/expiration.rs
+++ b/src/operation/expiration.rs
@@ -1,0 +1,19 @@
+use std::cmp::Ordering;
+
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]
+pub struct Expiration {
+    pub key: String,
+    pub timestamp: i64,
+}
+
+impl Expiration {
+    pub fn new(key: String, timestamp: i64) -> Self {
+        Expiration { key, timestamp }
+    }
+}
+
+impl Ord for Expiration {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.timestamp.cmp(&self.timestamp)
+    }
+}

--- a/src/operation/expiration.rs
+++ b/src/operation/expiration.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-#[derive(Debug, Clone, Eq, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Expiration {
     pub key: String,
     pub timestamp: i64,
@@ -15,5 +15,23 @@ impl Expiration {
 impl Ord for Expiration {
     fn cmp(&self, other: &Self) -> Ordering {
         other.timestamp.cmp(&self.timestamp)
+    }
+}
+
+impl PartialOrd for Expiration {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn orders_in_reverse() {
+        let a = Expiration::new("a".to_string(), 1);
+        let b = Expiration::new("b".to_string(), 2);
+        assert!(b < a);
     }
 }

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -226,17 +226,18 @@ mod tests {
     #[test]
     fn parse_expire() {
         let test_statement = "EXPIRE key 100";
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
         let operation = Operation::parse(test_statement.to_string());
-        assert_eq!(
-            operation,
-            Ok(Operation::ExpireAt(Expiration::new(
-                "key".to_string(),
-                SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs() as i64
-                    + 100
-            ))),
-        );
+
+        match operation {
+            Ok(Operation::ExpireAt(Expiration { key, timestamp })) => {
+                assert_eq!(key, "key".to_string());
+                assert!(timestamp + now > 100);
+            }
+            _ => assert!(false),
+        }
     }
 }

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -83,6 +83,8 @@ impl Operation {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+
     use super::*;
 
     #[test]

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -13,6 +13,7 @@ pub enum Operation {
     Put(String, Value),
     Delete(String),
     ExpireAt(Expiration),
+    Time,
     Purge,
 }
 
@@ -50,10 +51,10 @@ impl Operation {
                     .parse::<i64>()
                     .map_err(|_| TransactionError::InvalidValue("timestamp".to_string()))?;
 
-                Ok(Operation::ExpireAt(Expiration::new(
+                return Ok(Operation::ExpireAt(Expiration::new(
                     key.to_string(),
                     timestamp,
-                )))
+                )));
             }
             Some("EXPIRE") => {
                 let key = parts.next().ok_or(TransactionError::MissingKey)?;
@@ -73,6 +74,7 @@ impl Operation {
                     timestamp,
                 )))
             }
+            Some("TIME") => Ok(Operation::Time),
             Some(other) => Err(TransactionError::UnknownCommand(other.to_string())),
             None => Err(TransactionError::MissingCommand),
         }

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -65,7 +65,7 @@ impl Operation {
                 let timestamp = SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .unwrap()
-                    .as_secs() as i64
+                    .as_millis() as i64
                     + duration;
 
                 Ok(Operation::ExpireAt(Expiration::new(

--- a/src/operation/mod.rs
+++ b/src/operation/mod.rs
@@ -83,7 +83,6 @@ impl Operation {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
 
     use super::*;
 

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -34,6 +34,7 @@ impl WriteAheadLog {
                 self.clear()?;
                 String::from("")
             }
+            Operation::ExpireAt(key, timestamp) => format!("EXPIREAT {} {}\n", key, timestamp),
         };
 
         self.file

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -34,6 +34,7 @@ impl WriteAheadLog {
                 self.clear()?;
                 String::from("")
             }
+            Operation::Time => return Ok(()),
             Operation::ExpireAt(expiration) => {
                 format!("EXPIREAT {} {}\n", expiration.key, expiration.timestamp)
             }

--- a/src/wal/mod.rs
+++ b/src/wal/mod.rs
@@ -34,7 +34,9 @@ impl WriteAheadLog {
                 self.clear()?;
                 String::from("")
             }
-            Operation::ExpireAt(key, timestamp) => format!("EXPIREAT {} {}\n", key, timestamp),
+            Operation::ExpireAt(expiration) => {
+                format!("EXPIREAT {} {}\n", expiration.key, expiration.timestamp)
+            }
         };
 
         self.file

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -1,0 +1,49 @@
+use std::{thread, time::Duration};
+
+pub struct Worker<F>
+where
+    F: Fn() + Send + Clone + 'static,
+{
+    task: F,
+    interval: u64,
+}
+
+impl<F> Worker<F>
+where
+    F: Fn() + Send + Clone + 'static,
+{
+    pub fn new(interval: u64, task: F) -> Self {
+        Worker { task, interval }
+    }
+
+    pub fn start(&self) -> thread::JoinHandle<()> {
+        let task = self.task.clone();
+        let interval = self.interval;
+
+        thread::spawn(move || loop {
+            task();
+            thread::sleep(Duration::from_millis(interval));
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    #[test]
+    fn test_worker() {
+        let x = Arc::new(Mutex::new(0));
+        let x_clone = Arc::clone(&x);
+        let worker = Worker::new(100, move || {
+            let mut x = x_clone.lock().unwrap();
+            *x += 1;
+        });
+        let worker_thread = worker.start();
+        thread::sleep(Duration::from_millis(500));
+        drop(worker_thread);
+        assert_eq!(*x.lock().unwrap(), 5);
+    }
+}


### PR DESCRIPTION
Add EXPIRE and EXPIREAT commands using milliseconds and UNIX timestamps
Created Expiration heap to manage oldest expirations first
Configured heap to invalidate repeat items 
Set expirations heap to be cleared on request and set up worker to clear it periodically (5 second intervals)
Set up unit tests to confirm correct operation of expirations